### PR TITLE
remove basic auth from shared config files

### DIFF
--- a/n8n-deployment.yaml
+++ b/n8n-deployment.yaml
@@ -40,19 +40,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: POSTGRES_NON_ROOT_PASSWORD
-            - name: N8N_BASIC_AUTH_ACTIVE
-              value: "true"
-            - name: N8N_BASIC_AUTH_USER
-              valueFrom:
-                secretKeyRef:
-                  name: n8n-secret
-                  key: N8N_BASIC_AUTH_USER
-            - name: N8N_BASIC_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: n8n-secret
-                  key: N8N_BASIC_AUTH_PASSWORD   
+                  key: POSTGRES_NON_ROOT_PASSWORD 
             - name: N8N_PROTOCOL
               value: http
             - name: N8N_PORT

--- a/n8n-secret.yaml
+++ b/n8n-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  namespace: n8n
-  name: n8n-secret
-type: Opaque
-stringData:
-  N8N_BASIC_AUTH_USER: changeUser
-  N8N_BASIC_AUTH_PASSWORD: changePassword


### PR DESCRIPTION
This removes basic auth from the shared config files (i.e. the ones used by all branches)

I have tested locally with minikube. I haven't tested on any of the providers.

Once we're happy with it, it needs merging to each provider branch, as well as `main`