### PR TITLE
Fix azure deployment

### DIFF
--- a/n8n-deployment.yaml
+++ b/n8n-deployment.yaml
@@ -41,7 +41,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: POSTGRES_NON_ROOT_PASSWORD 
+                  key: POSTGRES_NON_ROOT_PASSWORD
             - name: N8N_PROTOCOL
               value: http
             - name: N8N_PORT

--- a/n8n-deployment.yaml
+++ b/n8n-deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         service: n8n
     spec:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown 1000:1000 /data"]
+          volumeMounts:
+            - name: n8n-claim0
+              mountPath: /data
       containers:
         - command:
             - /bin/sh


### PR DESCRIPTION
Hi guys,

we noticed two issues when setting up n8n in Azure by following [the documentation](https://docs.n8n.io/hosting/installation/server-setups/azure/).

### entrypoint/command not correctly set
We noticed that the pod did not start as the entrypoint or command in kubernetes terms is not set correctly. The `aws` and `main` branch look good, [`gcp`](https://github.com/n8n-io/n8n-kubernetes-hosting/blob/7ae0bd2edd3342ca32052a99303bab410753a57a/n8n-deployment.yaml#L21-L24) and `azure` seem to be incorrect.
I'm only opening a fix here for `azure` for now.

### volume permissions wrong
Second thing (for which I can ofc open another MR, maybe even to the `main` branch) is that n8n didn't have write permissions in the folder where the PersistentVolume is mounted.
The file systems on these PVs are quite often owned by root by default, n8n runs with the node user with uid/gid 1000 and doesn't have any permissions there.
A simple cross-cloud-provider solution is to add an init container which runs as root and sets the uid/gid on the PVs file system to 1000.

### kustomize
Another suggestion I have is to use `kustomize` with folders in a single branch instead of branches that get out of sync (as with the first issue).
I noticed that the differences between cloud provider branches compared to `main` are minimal, so kustomize would be an easy solution to simplify this repo.

kustomize included in kubectl since quite some time, the change would require you to not run the following on the main branch:
```sh
kubectl apply -f .
```
but instead
```sh
kubectl apply -k azure/ # or any other cloud provider
```

Let me know what you think!

Best, Vincent