### PR TITLE
add kustomize support

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- n8n-claim0-persistentvolumeclaim.yaml
+- n8n-deployment.yaml
+- n8n-service.yaml
+- postgres-claim0-persistentvolumeclaim.yaml
+- postgres-configmap.yaml
+- postgres-deployment.yaml
+- postgres-secret.yaml
+- postgres-service.yaml


### PR DESCRIPTION
By adding the `kustomization.yaml` we allow this repository be to easily patched via `kustomize` (also embedded on `kubectl`) to adjust settings for different environments.

## Extending via `kustomization.yaml`

A consumer project can reference this repository like this:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  # for testing this PR, use: github.com/kumbuca/n8n-kubernetes-hosting
  - github.com/n8n-io/n8n-kubernetes-hosting?ref=main
```

This can be applied with `kubectl apply -k .`

## Rendering directly with `kubectl`:

```
kubectl kustomize "github.com/n8n-io/n8n-kubernetes-hosting"
kubectl apply -k "github.com/n8n-io/n8n-kubernetes-hosting?ref=main"
```